### PR TITLE
Remove automatic call to next() in deleteMessage() and changeMessageVisibility()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ var queue = new SqsQueueParallel({
 	maxNumberOfMessages: 4,
 	concurrency: 2
 });
-queue.on('message', function (e, next)
+queue.on('message', function (e)
 {
 	console.log('New message: ', e.metadata, e.data.MessageId)
-	e.deleteMessage()
+	e.deleteMessage(function(err, data) {
+	    e.next();
+	});
 });
 queue.on('error', function (err)
 {
@@ -221,7 +223,7 @@ function(err, data) {}
 
 For more information take checkout the official [AWS documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#deleteMessage-property).
 
-**Esample:**
+**Example:**
 
 ```javascript
 var SqsQueueParallel = require('src/sqs-queue-parallel');
@@ -231,7 +233,9 @@ queue.deleteMessage('receipt-handle-to-delete-1');
 queue.on('message', function (job)
 {
 	if (myTest is true)
-		job.deleteMessage();
+		job.deleteMessage(function(err, data) {
+		    job.next();
+		});
 });
 ```
 

--- a/dist/sqs-queue-parallel.js
+++ b/dist/sqs-queue-parallel.js
@@ -61,6 +61,7 @@
             }
             return self.client.receiveMessage((options = {
               QueueUrl: self.url,
+              AttributeNames: ["All"],
               MaxNumberOfMessages: self.config.maxNumberOfMessages,
               WaitTimeSeconds: self.config.waitTimeSeconds
             }, self.config.visibilityTimeout != null ? options.VisibilityTimeout = self.config.visibilityTimeout : void 0, options), next);

--- a/dist/sqs-queue-parallel.js
+++ b/dist/sqs-queue-parallel.js
@@ -1,5 +1,5 @@
 /**
- * sqs-queue-parallel 0.1.5 <https://github.com/bigluck/sqs-queue-parallel>
+ * sqs-queue-parallel 0.1.6 <https://github.com/bigluck/sqs-queue-parallel>
  * Create a poll of Amazon SQS queue watchers and each one can receive 1+ messages
  *
  * Available under MIT license <https://github.com/bigluck/sqs-queue-parallel/raw/master/LICENSE>
@@ -82,14 +82,12 @@
                 name: self.config.name,
                 next: next,
                 deleteMessage: function(cb) {
-                  next();
                   return self.deleteMessage(message.ReceiptHandle, cb);
                 },
                 delay: function(timeout, cb) {
                   return self.changeMessageVisibility(message.ReceiptHandle, timeout, cb);
                 },
                 changeMessageVisibility: function(timeout, cb) {
-                  next();
                   return self.changeMessageVisibility(message.ReceiptHandle, timeout, cb);
                 }
               });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/sqs-queue-parallel",
 	"homepage": "https://github.com/bigluck/sqs-queue-parallel",
 	"author": "Luca Bigon",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"license": "MIT",
 	"licenses": [
 		{

--- a/src/sqs-queue-parallel.coffee
+++ b/src/sqs-queue-parallel.coffee
@@ -32,6 +32,7 @@ module.exports = class SqsQueueParallel extends events.EventEmitter
 					self.client.receiveMessage (
 						options =
 							QueueUrl: self.url
+							AttributeNames: ["All"]
 							MaxNumberOfMessages: self.config.maxNumberOfMessages
 							WaitTimeSeconds: self.config.waitTimeSeconds
 						options.VisibilityTimeout = self.config.visibilityTimeout if self.config.visibilityTimeout?
@@ -42,7 +43,7 @@ module.exports = class SqsQueueParallel extends events.EventEmitter
 					return next null unless queue.Messages?[0]
 					console.log "SqsQueueParallel #{ self.config.name }[#{ index }]: #{ queue.Messages.length } new messages" if self.config.debug
 					async.eachSeries queue.Messages, (message, next) ->
-						self.emit "message", 
+						self.emit "message",
 							type: 'message'
 							data: JSON.parse(message.Body) or message.Body
 							message: message
@@ -94,7 +95,7 @@ module.exports = class SqsQueueParallel extends events.EventEmitter
 				self.client.listQueues
 					QueueNamePrefix: self.config.name
 				, next
-			(data, next) -> 
+			(data, next) ->
 				re = new RegExp "/[\\d]+/#{ self.config.name }$"
 				self.emit 'connection', data.QueueUrls
 				self.emit 'connect', self.url = url for url in data.QueueUrls when re.test url

--- a/src/sqs-queue-parallel.coffee
+++ b/src/sqs-queue-parallel.coffee
@@ -51,12 +51,10 @@ module.exports = class SqsQueueParallel extends events.EventEmitter
 							name: self.config.name
 							next: next
 							deleteMessage: (cb) ->
-								next()
 								self.deleteMessage message.ReceiptHandle, cb
 							delay: (timeout, cb) ->
 								self.changeMessageVisibility message.ReceiptHandle, timeout, cb
 							changeMessageVisibility: (timeout, cb) ->
-								next()
 								self.changeMessageVisibility message.ReceiptHandle, timeout, cb
 					, ->
 						next null

--- a/test/app.coffee
+++ b/test/app.coffee
@@ -5,9 +5,9 @@ queue = new SqsQueueParallel
 	maxNumberOfMessages: 4
 	concurrency: 2
 
-queue.on 'message', (e, next) ->
+queue.on 'message', (e) ->
 	console.log 'New message: ', e.metadata, e.data.MessageId
-	e.delete()
+	e.deleteMessage()
 	e.next()
 
 queue.on 'error', (err) ->


### PR DESCRIPTION
When running with a high concurrency level and a queue with many message it is highly probable that the call to deleteMessage() will get scheduled for execution longer in the future than the visibility timeout of the received message.

This pull request removes the automatic call to next() and instead expects the user to call it explicitly.  For safety it can be called in the deleteMessage() callback.  For speed it can be called immediately after calling deleteMessage().

Also updated the docs and the tests.
