### PR TITLE
Fixed issue where error was thrown when message body is not JSON

### DIFF
--- a/dist/sqs-queue-parallel.js
+++ b/dist/sqs-queue-parallel.js
@@ -1,5 +1,5 @@
 /**
- * sqs-queue-parallel 0.1.6 <https://github.com/bigluck/sqs-queue-parallel>
+ * sqs-queue-parallel 0.1.7 <https://github.com/bigluck/sqs-queue-parallel>
  * Create a poll of Amazon SQS queue watchers and each one can receive 1+ messages
  *
  * Available under MIT license <https://github.com/bigluck/sqs-queue-parallel/raw/master/LICENSE>

--- a/dist/sqs-queue-parallel.js
+++ b/dist/sqs-queue-parallel.js
@@ -74,9 +74,15 @@
               console.log("SqsQueueParallel " + self.config.name + "[" + index + "]: " + queue.Messages.length + " new messages");
             }
             return async.eachSeries(queue.Messages, function(message, next) {
+              var data;
+              try {
+                data = JSON.parse(message.Body);
+              } catch (_error) {
+                data = message.Body;
+              }
               return self.emit("message", {
                 type: 'message',
-                data: JSON.parse(message.Body) || message.Body,
+                data: data,
                 message: message,
                 metadata: queue.ResponseMetadata,
                 url: self.url,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/sqs-queue-parallel",
 	"homepage": "https://github.com/bigluck/sqs-queue-parallel",
 	"author": "Luca Bigon",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"license": "MIT",
 	"licenses": [
 		{

--- a/src/sqs-queue-parallel.coffee
+++ b/src/sqs-queue-parallel.coffee
@@ -43,12 +43,10 @@ module.exports = class SqsQueueParallel extends events.EventEmitter
 					return next null unless queue.Messages?[0]
 					console.log "SqsQueueParallel #{ self.config.name }[#{ index }]: #{ queue.Messages.length } new messages" if self.config.debug
 					async.eachSeries queue.Messages, (message, next) ->
-
 						try
 					    	data = JSON.parse(message.Body)
 						catch
 							data = message.Body
-
 						self.emit "message",
 							type: 'message'
 							data: data

--- a/src/sqs-queue-parallel.coffee
+++ b/src/sqs-queue-parallel.coffee
@@ -43,9 +43,15 @@ module.exports = class SqsQueueParallel extends events.EventEmitter
 					return next null unless queue.Messages?[0]
 					console.log "SqsQueueParallel #{ self.config.name }[#{ index }]: #{ queue.Messages.length } new messages" if self.config.debug
 					async.eachSeries queue.Messages, (message, next) ->
+
+						try
+					    	data = JSON.parse(message.Body)
+						catch
+							data = message.Body
+
 						self.emit "message",
 							type: 'message'
-							data: JSON.parse(message.Body) or message.Body
+							data: data
 							message: message
 							metadata: queue.ResponseMetadata
 							url: self.url

--- a/src/sqs-queue-parallel.coffee
+++ b/src/sqs-queue-parallel.coffee
@@ -44,7 +44,7 @@ module.exports = class SqsQueueParallel extends events.EventEmitter
 					console.log "SqsQueueParallel #{ self.config.name }[#{ index }]: #{ queue.Messages.length } new messages" if self.config.debug
 					async.eachSeries queue.Messages, (message, next) ->
 						try
-					    	data = JSON.parse(message.Body)
+							data = JSON.parse(message.Body)
 						catch
 							data = message.Body
 						self.emit "message",


### PR DESCRIPTION
In cases where the message's body is not JSON, trying to parse the body as JSON throws an error and crashes the process.

To prevent this from happening, we can attempt to parse the message body in a try block. If the message is not valid JSON, the catch block catches the error and then assigns the raw message string as the data.
